### PR TITLE
chore: update Plausible analytics script ID

### DIFF
--- a/src/2022.html
+++ b/src/2022.html
@@ -11,7 +11,7 @@
     gtag('config', 'G-5DP1VPFXVL');
   </script>
   <!-- Privacy-friendly analytics by Plausible -->
-  <script async src="https://plausible.io/js/pa-55W8pukXO5kBLvpl06mhx.js"></script>
+  <script async src="https://plausible.io/js/pa-PFruVsE_br97UUCRXE_6f.js"></script>
   <script>
     window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
     plausible.init()

--- a/src/2023.html
+++ b/src/2023.html
@@ -11,7 +11,7 @@
     gtag('config', 'G-5DP1VPFXVL');
   </script>
   <!-- Privacy-friendly analytics by Plausible -->
-  <script async src="https://plausible.io/js/pa-55W8pukXO5kBLvpl06mhx.js"></script>
+  <script async src="https://plausible.io/js/pa-PFruVsE_br97UUCRXE_6f.js"></script>
   <script>
     window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
     plausible.init()

--- a/src/2024.html
+++ b/src/2024.html
@@ -11,7 +11,7 @@
     gtag('config', 'G-5DP1VPFXVL');
   </script>
   <!-- Privacy-friendly analytics by Plausible -->
-  <script async src="https://plausible.io/js/pa-55W8pukXO5kBLvpl06mhx.js"></script>
+  <script async src="https://plausible.io/js/pa-PFruVsE_br97UUCRXE_6f.js"></script>
   <script>
     window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
     plausible.init()

--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
     gtag('config', 'G-5DP1VPFXVL');
   </script>
   <!-- Privacy-friendly analytics by Plausible -->
-  <script async src="https://plausible.io/js/pa-55W8pukXO5kBLvpl06mhx.js"></script>
+  <script async src="https://plausible.io/js/pa-PFruVsE_br97UUCRXE_6f.js"></script>
   <script>
     window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
     plausible.init()


### PR DESCRIPTION
Replace the privacy-friendly Plausible tracking script source ID across all HTML pages to use the new measurement endpoint.

This is done so we can use the smallest plan with Plausible. In use, it will mean that we will need to filter by hostname, which is easy to do :)